### PR TITLE
feat(ci): use GHA for publishing to Pages

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,0 +1,23 @@
+name: Publish to Pages
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          lfs: true
+
+      - # Make sure we only include the helm repository files
+        run: |
+          mkdir _site
+          mv *.tgz index.yaml _site/
+
+      - uses: actions/upload-page-artifact@v1
+        with:
+          path: _site/

--- a/.github/workflows/update-repo-index.yaml
+++ b/.github/workflows/update-repo-index.yaml
@@ -7,7 +7,7 @@ on:
       - "*.tgz"
 
 jobs:
-  publish:
+  index:
     runs-on: ubuntu-latest
     steps:
       - uses: azure/setup-helm@v3


### PR DESCRIPTION
Default Jekyll publishing also includes all other files in the repository.